### PR TITLE
Adding a flag to handle signature setup if the chain supports the Metadata hash

### DIFF
--- a/api/src/test/java/com/strategyobject/substrateclient/api/pallet/balances/BalancesTest.java
+++ b/api/src/test/java/com/strategyobject/substrateclient/api/pallet/balances/BalancesTest.java
@@ -97,7 +97,7 @@ class BalancesTest {
         val tip = 0;
         val call = new BalanceTransfer(moduleIndex, callIndex, AddressId.fromBytes(bobKeyPair().asPublicKey().getBytes()), BigInteger.valueOf(10));
 
-        val extra = new SignedExtra<>(specVersion, txVersion, genesis, genesis, new ImmortalEra(), Index.of(0), BigInteger.valueOf(tip));
+        val extra = new SignedExtra<>(specVersion, txVersion, genesis, genesis, new ImmortalEra(), Index.of(0), BigInteger.valueOf(tip), true);
         val signedPayload = ScaleUtils.toBytes(
                 new SignedPayload<>(call, extra),
                 TestsHelper.SCALE_WRITER_REGISTRY,

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedAdditionalExtra.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedAdditionalExtra.java
@@ -2,39 +2,45 @@ package com.strategyobject.substrateclient.rpc.api;
 
 import com.strategyobject.substrateclient.rpc.api.primitives.BlockHash;
 import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.annotation.Ignore;
 import com.strategyobject.substrateclient.scale.annotation.Scale;
 import com.strategyobject.substrateclient.scale.annotation.ScaleGeneric;
-import com.strategyobject.substrateclient.scale.annotation.ScaleWriter;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.NonNull;
 
-import java.util.Optional;
-
 @Getter
-@ScaleWriter
 public class SignedAdditionalExtra implements AdditionalExtra {
-    @Scale(ScaleType.U32.class)
-    private final long specVersion;
-    @Scale(ScaleType.U32.class)
-    private final long txVersion;
-    private final BlockHash genesis;
-    private final BlockHash eraBlock;
-    @ScaleGeneric(
-        template = "Option<U8>",
-        types = {
-            @Scale(ScaleType.Option.class),
-            @Scale(ScaleType.U8.class)
-        }
-    )
-    private final Optional<Integer> metadataHash;
 
-    public SignedAdditionalExtra(long specVersion, long txVersion, @NonNull BlockHash genesis, @NonNull BlockHash eraBlock) {
-        this.specVersion = (int) specVersion;
-        this.txVersion = (int) txVersion;
-        this.genesis = genesis;
-        this.eraBlock = eraBlock;
-        metadataHash = Optional.empty();
-        // Set the metadata hash if we use it
-        // this.metadataHash = 0;
-    }
+  @Scale(ScaleType.U32.class)
+  private final long specVersion;
+
+  @Scale(ScaleType.U32.class)
+  private final long txVersion;
+
+  private final BlockHash genesis;
+  private final BlockHash eraBlock;
+
+  @Ignore
+  private final boolean hasMetadataHashSupport;
+
+  @ScaleGeneric(template = "Option<U8>", types = { @Scale(ScaleType.Option.class), @Scale(ScaleType.U8.class) })
+  private final Optional<Integer> metadataHash;
+
+  public SignedAdditionalExtra(
+    long specVersion,
+    long txVersion,
+    @NonNull BlockHash genesis,
+    @NonNull BlockHash eraBlock,
+    boolean hasMetadataHashSupport
+  ) {
+    this.specVersion = (int) specVersion;
+    this.txVersion = (int) txVersion;
+    this.genesis = genesis;
+    this.eraBlock = eraBlock;
+    this.hasMetadataHashSupport = hasMetadataHashSupport;
+    metadataHash = Optional.empty();
+    // Set the metadata hash if we use it
+    // this.metadataHash = 0;
+  }
 }

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedAdditionalExtraWriter.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedAdditionalExtraWriter.java
@@ -1,0 +1,48 @@
+package com.strategyobject.substrateclient.rpc.api;
+
+import com.strategyobject.substrateclient.rpc.api.primitives.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.annotation.AutoRegister;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.Exception;
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.RuntimeException;
+import java.lang.SuppressWarnings;
+
+@AutoRegister(
+    types = {com.strategyobject.substrateclient.rpc.api.SignedAdditionalExtra.class}
+)
+public class SignedAdditionalExtraWriter implements ScaleWriter<SignedAdditionalExtra> {
+  private final ScaleWriterRegistry registry;
+
+  public SignedAdditionalExtraWriter(ScaleWriterRegistry registry) {
+    if (registry == null) {
+      throw new IllegalArgumentException("registry can't be null.");
+    }
+    this.registry = registry;
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked"})
+  public void write(SignedAdditionalExtra value, OutputStream stream, ScaleWriter<?>... writers)
+      throws IOException {
+    if (stream == null) throw new IllegalArgumentException("stream is null");
+    if (value == null) throw new IllegalArgumentException("value is null");
+    if (writers != null && writers.length > 0) throw new IllegalArgumentException();
+    try {
+      ((ScaleWriter)registry.resolve(ScaleType.U32.class)).write(value.getSpecVersion(), stream);
+      ((ScaleWriter)registry.resolve(ScaleType.U32.class)).write(value.getTxVersion(), stream);
+      ((ScaleWriter)registry.resolve(BlockHash.class)).write(value.getGenesis(), stream);
+      ((ScaleWriter)registry.resolve(BlockHash.class)).write(value.getEraBlock(), stream);
+      if (value.isHasMetadataHashSupport()) {
+        ((ScaleWriter)registry.resolve(ScaleType.Option.class).inject(registry.resolve(ScaleType.U8.class))).write(value.getMetadataHash(), stream);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedExtra.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedExtra.java
@@ -25,11 +25,13 @@ public class SignedExtra<E extends Era> implements Extra, SignedExtension {
     private final Index nonce;
     @Scale(ScaleType.CompactBigInteger.class)
     private final BigInteger tip;
+    @Ignore
+    private final boolean hasMetadataHashSupport;
     // TODO: Support Metadata Hash
     private final MetadataHashMode mode = MetadataHashMode.DISABLED;
 
     @Override
     public AdditionalExtra getAdditionalExtra() {
-        return new SignedAdditionalExtra(specVersion, txVersion, genesis, eraBlock);
+        return new SignedAdditionalExtra(specVersion, txVersion, genesis, eraBlock, this.hasMetadataHashSupport);
     }
 }

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedExtraWriter.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/SignedExtraWriter.java
@@ -29,6 +29,8 @@ public class SignedExtraWriter<E extends Era> implements ScaleWriter<SignedExtra
         ((ScaleWriter<E>) dispatcher).write(value.getEra(), stream);
         ((ScaleWriter<Index>) registry.resolve(Index.class)).write(value.getNonce(), stream);
         ((ScaleWriter<BigInteger>) registry.resolve(ScaleType.CompactBigInteger.class)).write(value.getTip(), stream);
-        ((ScaleWriter)registry.resolve(MetadataHashMode.class)).write(value.getMode(), stream);
+        if (value.isHasMetadataHashSupport()) {
+          ((ScaleWriter)registry.resolve(MetadataHashMode.class)).write(value.getMode(), stream);
+        }
     }
 }

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/SignedExtraTest.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/SignedExtraTest.java
@@ -1,0 +1,95 @@
+package com.strategyobject.substrateclient.api.pallet.balances;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.strategyobject.substrateclient.common.convert.HexConverter;
+import com.strategyobject.substrateclient.rpc.api.ImmortalEra;
+import com.strategyobject.substrateclient.rpc.api.SignedAdditionalExtra;
+import com.strategyobject.substrateclient.rpc.api.SignedExtra;
+import com.strategyobject.substrateclient.rpc.api.primitives.BlockHash;
+import com.strategyobject.substrateclient.rpc.api.primitives.Hash256;
+import com.strategyobject.substrateclient.rpc.api.primitives.Index;
+import com.strategyobject.substrateclient.rpc.api.section.TestsHelper;
+import com.strategyobject.substrateclient.scale.ScaleUtils;
+import com.strategyobject.substrateclient.tests.containers.FrequencyVersion;
+import java.math.BigInteger;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SignedExtraTest {
+
+  private static final long SPEC_VERSION = FrequencyVersion.SPEC;
+  private static final int TX_VERSION = 1;
+  private static final int TIP = 0;
+
+  private BlockHash genesis;
+
+  @BeforeEach
+  void setUp() {
+    genesis = Hash256.fromBytes(
+      HexConverter.toBytes("0x7700000000000000000000000000000000000000000000000000000000000077")
+    );
+  }
+
+  /**
+   * Tests the serialization of SignedExtra with and without metadata hash.
+   *
+   * @param includeMetadataHash whether to include metadata hash in the SignedExtra
+   * @param expectedHash the expected hex output of the SCALE data
+   * @throws Exception if an error occurs during serialization
+   */
+  @ParameterizedTest
+  @CsvSource({ "false,0x000000", "true,0x00000000" })
+  void testSignedExtra(boolean includeMetadataHash, String expectedHash) throws Exception {
+    val extra = new SignedExtra<>(
+      SPEC_VERSION,
+      TX_VERSION,
+      genesis,
+      genesis,
+      new ImmortalEra(),
+      Index.of(0),
+      BigInteger.valueOf(TIP),
+      includeMetadataHash
+    );
+    byte[] signedExtraBytes = ScaleUtils.toBytes(extra, TestsHelper.SCALE_WRITER_REGISTRY, SignedExtra.class);
+
+    assertThat("Expected hex output", HexConverter.toHex(signedExtraBytes), equalTo(expectedHash));
+  }
+
+  /**
+   * Tests the serialization of SignedExtraAdditional with and without metadata hash.
+   *
+   * @param includeMetadataHash whether to include metadata hash in the SignedExtra
+   * @param expectedHash the expected hex output of the SCALE data
+   * @throws Exception if an error occurs during serialization
+   */
+  @ParameterizedTest
+  @CsvSource(
+    {
+      "false,0x6e0000000100000077000000000000000000000000000000000000000000000000000000000000777700000000000000000000000000000000000000000000000000000000000077",
+      "true,0x6e000000010000007700000000000000000000000000000000000000000000000000000000000077770000000000000000000000000000000000000000000000000000000000007700",
+    }
+  )
+  void testSignedExtraAdditional(boolean includeMetadataHash, String expectedHash) throws Exception {
+    val extra = new SignedExtra<>(
+      SPEC_VERSION,
+      TX_VERSION,
+      genesis,
+      genesis,
+      new ImmortalEra(),
+      Index.of(0),
+      BigInteger.valueOf(TIP),
+      includeMetadataHash
+    );
+    byte[] signedExtraAdditionalBytes = ScaleUtils.toBytes(
+      extra.getAdditionalExtra(),
+      TestsHelper.SCALE_WRITER_REGISTRY,
+      SignedAdditionalExtra.class
+    );
+
+    assertThat("Expected hex output", HexConverter.toHex(signedExtraAdditionalBytes), equalTo(expectedHash));
+  }
+}

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
@@ -152,7 +152,7 @@ class AuthorTests {
         val tip = 0;
         val call = new BalanceTransfer(moduleIndex, callIndex, AddressId.fromBytes(bobKeyPair().asPublicKey().getBytes()), BigInteger.valueOf(10));
 
-        val extra = new SignedExtra<>(specVersion, txVersion, genesis, genesis, new ImmortalEra(), Index.of(nonce), BigInteger.valueOf(tip));
+        val extra = new SignedExtra<>(specVersion, txVersion, genesis, genesis, new ImmortalEra(), Index.of(nonce), BigInteger.valueOf(tip), true);
         val signedPayload = ScaleUtils.toBytes(
                 new SignedPayload<>(call, extra),
                 TestsHelper.SCALE_WRITER_REGISTRY,

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/TestsHelper.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/TestsHelper.java
@@ -25,7 +25,7 @@ public class TestsHelper {
         registerAnnotatedFrom("com.strategyobject.substrateclient");
     }};
 
-    static final ScaleWriterRegistry SCALE_WRITER_REGISTRY = new ScaleWriterRegistry() {{
+    public static final ScaleWriterRegistry SCALE_WRITER_REGISTRY = new ScaleWriterRegistry() {{
         registerAnnotatedFrom("com.strategyobject.substrateclient");
     }};
 


### PR DESCRIPTION
Adding a flag to the SignedExtra for if the chain supports the Metadata Hash extension or not

- [x] Test of SignedExtra
- [x] Test of SignedAdditionalExtra