### PR TITLE
Supports 65-byte signatures

### DIFF
--- a/common/src/main/java/com/strategyobject/substrateclient/common/types/Size.java
+++ b/common/src/main/java/com/strategyobject/substrateclient/common/types/Size.java
@@ -6,6 +6,7 @@ public interface Size {
     Zero zero = new Zero();
     Of32 of32 = new Of32();
     Of64 of64 = new Of64();
+    Of65 of65 = new Of65();
     Of96 of96 = new Of96();
     Of128 of128 = new Of128();
     Of256 of256 = new Of256();
@@ -28,6 +29,13 @@ public interface Size {
         @Override
         public int getValue() {
             return 64;
+        }
+    }
+
+    class Of65 implements Size {
+        @Override
+        public int getValue() {
+            return 65;
         }
     }
 

--- a/crypto/src/main/java/com/strategyobject/substrateclient/crypto/SignatureData.java
+++ b/crypto/src/main/java/com/strategyobject/substrateclient/crypto/SignatureData.java
@@ -4,12 +4,22 @@ import com.strategyobject.substrateclient.common.types.FixedBytes;
 import com.strategyobject.substrateclient.common.types.Size;
 import lombok.NonNull;
 
-public class SignatureData extends FixedBytes<Size.Of64> {
-    protected SignatureData(byte[] data) {
-        super(data, Size.of64);
+public class SignatureData extends FixedBytes<Size> {
+
+    protected SignatureData(byte @NonNull [] bytes, Size size) {
+        super(bytes, size);
     }
 
     public static SignatureData fromBytes(byte @NonNull [] data) {
-        return new SignatureData(data);
+        if (data.length == 64) {
+            return new SignatureData(data, Size.of64);
+        }
+        // NOTE(Julian, 2025-07-16): ECDSA (Secp256k1) signatures are 65 bytes
+        if (data.length == 65) {
+            return new SignatureData(data, Size.of65);
+        }
+
+        throw new IllegalArgumentException("Unsupported data size: " + data.length);
     }
+
 }


### PR DESCRIPTION
Part of ProjectLibertyLabs/custodial-wallet#1526